### PR TITLE
Feat/#7 add crawler info

### DIFF
--- a/src/main/java/knu/chcse/knucseofficialserver/application/notice/NoticeService.java
+++ b/src/main/java/knu/chcse/knucseofficialserver/application/notice/NoticeService.java
@@ -1,9 +1,7 @@
 package knu.chcse.knucseofficialserver.application.notice;
 
 import jakarta.transaction.Transactional;
-import knu.chcse.knucseofficialserver.application.notice.dto.CreateNoticeRequest;
-import knu.chcse.knucseofficialserver.application.notice.dto.NoticeResponse;
-import knu.chcse.knucseofficialserver.application.notice.dto.UpdateNoticeRequest;
+import knu.chcse.knucseofficialserver.application.notice.dto.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -16,5 +14,5 @@ public interface NoticeService {
     List<NoticeResponse> getNotices();
     void updateNotice(Long noticeId, Long studentNumber,UpdateNoticeRequest request);
     void deleteNotice(Long noticeId, Long studentNumber);
-
+    void sync(NoticeSyncRequest request);
 }

--- a/src/main/java/knu/chcse/knucseofficialserver/application/notice/NoticeServiceImpl.java
+++ b/src/main/java/knu/chcse/knucseofficialserver/application/notice/NoticeServiceImpl.java
@@ -1,11 +1,11 @@
 package knu.chcse.knucseofficialserver.application.notice;
 
-import knu.chcse.knucseofficialserver.application.notice.dto.CreateNoticeRequest;
-import knu.chcse.knucseofficialserver.application.notice.dto.NoticeResponse;
-import knu.chcse.knucseofficialserver.application.notice.dto.UpdateNoticeRequest;
+import knu.chcse.knucseofficialserver.application.notice.dto.*;
+import knu.chcse.knucseofficialserver.domain.entity.Notice;
 import knu.chcse.knucseofficialserver.domain.entity.board.Board;
 import knu.chcse.knucseofficialserver.domain.entity.board.BoardCategory;
 import knu.chcse.knucseofficialserver.domain.entity.board.BoardJpaRepository;
+import knu.chcse.knucseofficialserver.domain.entity.notice.NoticeRepository;
 import knu.chcse.knucseofficialserver.domain.entity.post.Post;
 import knu.chcse.knucseofficialserver.domain.entity.post.PostJpaRepository;
 import knu.chcse.knucseofficialserver.domain.entity.post.PostStatus;
@@ -18,6 +18,7 @@ import knu.chcse.knucseofficialserver.global.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.RequestBody;
 
 import java.util.List;
 
@@ -25,6 +26,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @Transactional
 public class NoticeServiceImpl implements NoticeService {
+    private final NoticeRepository  noticeRepository;
     private final PostJpaRepository postRepository;
     private final StudentJpaRepository studentRepository;
     private final BoardJpaRepository boardRepository;
@@ -97,6 +99,25 @@ public class NoticeServiceImpl implements NoticeService {
         post.delete();
     }
 
+    @Override
+    public void sync(NoticeSyncRequest request){
+        Student systemStudent = studentRepository.findById(1L).orElseThrow(
+                ()-> new IllegalArgumentException("시스템 유저가 없습니다.")
+        );
+        Board noticeBoard = boardRepository.findByCategory(BoardCategory.NOTICE).orElseThrow(
+                ()-> new IllegalArgumentException("공지 게시판이 없습니다.")
+        );
+
+        for(NoticeItemRequest item : request.data()){
+            Notice notice = noticeRepository.save(Notice.from(item));
+            Post post = Post.from(notice, systemStudent,noticeBoard);
+            postRepository.save(post);
+
+        }
+
+
+    }
+
     private Student checkAdminPermission(Long studentNumber){
         Student student = studentRepository.findByNumber(studentNumber).orElseThrow(
             ()-> new BusinessException(CommonErrorCode.INVALID_CREDENTIALS)
@@ -120,4 +141,5 @@ public class NoticeServiceImpl implements NoticeService {
 
         return post;
     }
+
 }

--- a/src/main/java/knu/chcse/knucseofficialserver/application/notice/NoticeServiceImpl.java
+++ b/src/main/java/knu/chcse/knucseofficialserver/application/notice/NoticeServiceImpl.java
@@ -1,10 +1,10 @@
 package knu.chcse.knucseofficialserver.application.notice;
 
 import knu.chcse.knucseofficialserver.application.notice.dto.*;
-import knu.chcse.knucseofficialserver.domain.entity.Notice;
 import knu.chcse.knucseofficialserver.domain.entity.board.Board;
 import knu.chcse.knucseofficialserver.domain.entity.board.BoardCategory;
 import knu.chcse.knucseofficialserver.domain.entity.board.BoardJpaRepository;
+import knu.chcse.knucseofficialserver.domain.entity.notice.Notice;
 import knu.chcse.knucseofficialserver.domain.entity.notice.NoticeRepository;
 import knu.chcse.knucseofficialserver.domain.entity.post.Post;
 import knu.chcse.knucseofficialserver.domain.entity.post.PostJpaRepository;
@@ -102,10 +102,10 @@ public class NoticeServiceImpl implements NoticeService {
     @Override
     public void sync(NoticeSyncRequest request){
         Student systemStudent = studentRepository.findById(1L).orElseThrow(
-                ()-> new IllegalArgumentException("시스템 유저가 없습니다.")
+                ()-> new BusinessException(CommonErrorCode.NOT_FOUND)
         );
         Board noticeBoard = boardRepository.findByCategory(BoardCategory.NOTICE).orElseThrow(
-                ()-> new IllegalArgumentException("공지 게시판이 없습니다.")
+                ()-> new BusinessException(CommonErrorCode.NOT_FOUND)
         );
 
         for(NoticeItemRequest item : request.data()){

--- a/src/main/java/knu/chcse/knucseofficialserver/application/notice/dto/NoticeItemRequest.java
+++ b/src/main/java/knu/chcse/knucseofficialserver/application/notice/dto/NoticeItemRequest.java
@@ -1,0 +1,22 @@
+package knu.chcse.knucseofficialserver.application.notice.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record NoticeItemRequest (
+    String category,
+
+    String content,
+
+    @JsonProperty("createdAt")
+    String createdAt,
+
+    String link,
+
+    Long num,
+
+    String title,
+
+    String status
+){
+
+}

--- a/src/main/java/knu/chcse/knucseofficialserver/application/notice/dto/NoticeSyncRequest.java
+++ b/src/main/java/knu/chcse/knucseofficialserver/application/notice/dto/NoticeSyncRequest.java
@@ -1,0 +1,9 @@
+package knu.chcse.knucseofficialserver.application.notice.dto;
+
+import java.util.List;
+
+public record NoticeSyncRequest (
+        List<NoticeItemRequest> data
+){
+
+}

--- a/src/main/java/knu/chcse/knucseofficialserver/domain/entity/notice/Notice.java
+++ b/src/main/java/knu/chcse/knucseofficialserver/domain/entity/notice/Notice.java
@@ -1,0 +1,101 @@
+package knu.chcse.knucseofficialserver.domain.entity.notice;
+
+import jakarta.persistence.*;
+import knu.chcse.knucseofficialserver.application.notice.dto.NoticeItemRequest;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "NOTICE_TABLE")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notice {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String category;
+
+    @Lob
+    private String content;
+
+    @Column(name = "created_at")
+    private String createdAt;
+
+    private String link;
+
+    private Long num;
+
+    @Column(name = "saved_at")
+    private LocalDateTime savedAt;
+
+    private String title;
+
+    private String status;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    public static Notice from(NoticeItemRequest item){
+        Notice notice = new Notice();
+        notice.category = item.category();
+        notice.content = item.content();
+        notice.createdAt = item.createdAt();
+        notice.link = item.link();
+        notice.num = item.num();
+        notice.savedAt = LocalDateTime.now();
+        notice.title = item.title();
+        notice.status = item.status();
+        notice.updatedAt = LocalDateTime.now();
+        return notice;
+    }
+    private Notice(
+            String category,
+            String content,
+            String createdAt,
+            String link,
+            Long num,
+            LocalDateTime savedAt,
+            String title,
+            String status,
+            LocalDateTime updatedAt
+    ) {
+        this.category = category;
+        this.content = content;
+        this.createdAt = createdAt;
+        this.link = link;
+        this.num = num;
+        this.savedAt = savedAt;
+        this.title = title;
+        this.status = status;
+        this.updatedAt = updatedAt;
+    }
+
+    public static Notice create(
+            String category,
+            String content,
+            String createdAt,
+            String link,
+            Long num,
+            LocalDateTime savedAt,
+            String title,
+            String status,
+            LocalDateTime updatedAt
+    ) {
+        return new Notice(
+                category,
+                content,
+                createdAt,
+                link,
+                num,
+                savedAt,
+                title,
+                status,
+                updatedAt
+        );
+    }
+}

--- a/src/main/java/knu/chcse/knucseofficialserver/domain/entity/notice/NoticeRepository.java
+++ b/src/main/java/knu/chcse/knucseofficialserver/domain/entity/notice/NoticeRepository.java
@@ -1,0 +1,16 @@
+package knu.chcse.knucseofficialserver.domain.entity.notice;
+
+import knu.chcse.knucseofficialserver.domain.entity.notice.Notice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface NoticeRepository extends JpaRepository<Notice,Long> {
+    Optional<Notice> findByNum(Long num);
+
+    Optional<Notice> findByLink(String link);
+
+    boolean existsByNum(Long num);
+
+    boolean existsByLink(String link);
+}

--- a/src/main/java/knu/chcse/knucseofficialserver/domain/entity/post/Post.java
+++ b/src/main/java/knu/chcse/knucseofficialserver/domain/entity/post/Post.java
@@ -1,6 +1,7 @@
 package knu.chcse.knucseofficialserver.domain.entity.post;
 
 import jakarta.persistence.*;
+import knu.chcse.knucseofficialserver.domain.entity.Notice;
 import knu.chcse.knucseofficialserver.domain.entity.common.BaseTimeEntity;
 import knu.chcse.knucseofficialserver.domain.entity.board.Board;
 import knu.chcse.knucseofficialserver.domain.entity.board.BoardCategory;
@@ -45,6 +46,20 @@ public class Post extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "post_status", nullable = false)
     private PostStatus status;
+
+    public static Post from(
+            Notice notice,
+            Student student,
+            Board board
+    ){
+        return Post.create(
+                student,
+                board,
+                notice.getTitle(),
+                notice.getContent(),
+                false
+        );
+    }
 
     //static factory method
     public static Post create(

--- a/src/main/java/knu/chcse/knucseofficialserver/domain/entity/post/Post.java
+++ b/src/main/java/knu/chcse/knucseofficialserver/domain/entity/post/Post.java
@@ -69,7 +69,6 @@ public class Post extends BaseTimeEntity {
         return this.board.getCategory() == BoardCategory.NOTICE;
     }
 
-    //domain 중심 설계
     public void update(String title, String content){
         this.title = title;
         this.content = content;
@@ -79,12 +78,10 @@ public class Post extends BaseTimeEntity {
         this.status = PostStatus.DELETED;
     }
 
-    // 상단 고정 토글 메서드 (추후 구현용)
     public void togglePin(){
         this.isPinned = !this.isPinned;
     }
 
-    // 조회수 증가 메서드
     public void incrementViewCount(){
         this.viewCount++;
     }

--- a/src/main/java/knu/chcse/knucseofficialserver/domain/entity/post/Post.java
+++ b/src/main/java/knu/chcse/knucseofficialserver/domain/entity/post/Post.java
@@ -1,7 +1,7 @@
 package knu.chcse.knucseofficialserver.domain.entity.post;
 
 import jakarta.persistence.*;
-import knu.chcse.knucseofficialserver.domain.entity.Notice;
+import knu.chcse.knucseofficialserver.domain.entity.notice.Notice;
 import knu.chcse.knucseofficialserver.domain.entity.common.BaseTimeEntity;
 import knu.chcse.knucseofficialserver.domain.entity.board.Board;
 import knu.chcse.knucseofficialserver.domain.entity.board.BoardCategory;

--- a/src/main/java/knu/chcse/knucseofficialserver/presentation/controller/NoticeController.java
+++ b/src/main/java/knu/chcse/knucseofficialserver/presentation/controller/NoticeController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import knu.chcse.knucseofficialserver.application.notice.NoticeService;
 import knu.chcse.knucseofficialserver.application.notice.dto.CreateNoticeRequest;
 import knu.chcse.knucseofficialserver.application.notice.dto.NoticeResponse;
+import knu.chcse.knucseofficialserver.application.notice.dto.NoticeSyncRequest;
 import knu.chcse.knucseofficialserver.application.notice.dto.UpdateNoticeRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -73,5 +74,15 @@ public class NoticeController implements NoticeControllerDocs {
         noticeService.deleteNotice(noticeId, studentNumber);
 
         return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/sync")
+    public ResponseEntity<Void> receiveNotices(
+            @RequestBody NoticeSyncRequest request
+    ){
+        int count = request.data() == null ? 0 : request.data().size();;
+
+        NoticeResponse response = noticeService.sync(request);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/knu/chcse/knucseofficialserver/presentation/controller/NoticeController.java
+++ b/src/main/java/knu/chcse/knucseofficialserver/presentation/controller/NoticeController.java
@@ -2,10 +2,7 @@ package knu.chcse.knucseofficialserver.presentation.controller;
 
 import jakarta.validation.Valid;
 import knu.chcse.knucseofficialserver.application.notice.NoticeService;
-import knu.chcse.knucseofficialserver.application.notice.dto.CreateNoticeRequest;
-import knu.chcse.knucseofficialserver.application.notice.dto.NoticeResponse;
-import knu.chcse.knucseofficialserver.application.notice.dto.NoticeSyncRequest;
-import knu.chcse.knucseofficialserver.application.notice.dto.UpdateNoticeRequest;
+import knu.chcse.knucseofficialserver.application.notice.dto.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -80,9 +77,10 @@ public class NoticeController implements NoticeControllerDocs {
     public ResponseEntity<Void> receiveNotices(
             @RequestBody NoticeSyncRequest request
     ){
-        int count = request.data() == null ? 0 : request.data().size();;
-
-        NoticeResponse response = noticeService.sync(request);
-        return ResponseEntity.ok(response);
+        if(request == null || request.data() == null || request.data().isEmpty()){
+            return ResponseEntity.badRequest().build();
+        }
+        noticeService.sync(request);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/test/java/knu/chcse/knucseofficialserver/application/notice/NoticeServiceImplTest.java
+++ b/src/test/java/knu/chcse/knucseofficialserver/application/notice/NoticeServiceImplTest.java
@@ -1,11 +1,11 @@
 package knu.chcse.knucseofficialserver.application.notice;
 
-import knu.chcse.knucseofficialserver.application.notice.dto.CreateNoticeRequest;
-import knu.chcse.knucseofficialserver.application.notice.dto.NoticeResponse;
-import knu.chcse.knucseofficialserver.application.notice.dto.UpdateNoticeRequest;
+import knu.chcse.knucseofficialserver.application.notice.dto.*;
+import knu.chcse.knucseofficialserver.domain.entity.notice.Notice;
 import knu.chcse.knucseofficialserver.domain.entity.board.Board;
 import knu.chcse.knucseofficialserver.domain.entity.board.BoardCategory;
 import knu.chcse.knucseofficialserver.domain.entity.board.BoardJpaRepository;
+import knu.chcse.knucseofficialserver.domain.entity.notice.NoticeRepository;
 import knu.chcse.knucseofficialserver.domain.entity.post.Post;
 import knu.chcse.knucseofficialserver.domain.entity.post.PostJpaRepository;
 import knu.chcse.knucseofficialserver.domain.entity.post.PostStatus;
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -37,12 +38,14 @@ public class NoticeServiceImplTest {
     private StudentJpaRepository studentJpaRepository;
     @Mock
     private BoardJpaRepository boardJpaRepository;
+    @Mock
+    private NoticeRepository noticeRepository;
 
     private NoticeServiceImpl noticeService;
 
     @BeforeEach
     void setUp(){
-        this.noticeService = new NoticeServiceImpl(postJpaRepository, studentJpaRepository, boardJpaRepository);
+        this.noticeService = new NoticeServiceImpl(noticeRepository,postJpaRepository, studentJpaRepository, boardJpaRepository);
     }
 
     @Test
@@ -403,6 +406,107 @@ public class NoticeServiceImplTest {
         assertEquals(NoticeErrorCode.NO_NOTICE_PERMISSION, ex.getErrorCode());
     }
 
+    @Test
+    @DisplayName("syncNotice: 성공")
+    void syncNotice_success(){
+        //given
+        NoticeItemRequest item1 = new NoticeItemRequest(
+                "공지1",
+                "1내용입니다",
+                "2026-03-24",
+                "https://example1.com",
+                1L,
+                "제목입니다",
+                "ACTIVE"
+        );
+
+        NoticeItemRequest item2 = new NoticeItemRequest(
+                "공지2",
+                "2내용입니다",
+                "2026-03-24",
+                "https://example2.com",
+                2L,
+                "제목입니다",
+                "ACTIVE"
+        );
+
+        NoticeSyncRequest request = new NoticeSyncRequest(List.of(item1,item2));
+
+        Student student = mock(Student.class);
+        Board noticeBoard = mock(Board.class);
+
+        when(studentJpaRepository.findById(1L)).thenReturn(Optional.of(student));
+        when(boardJpaRepository.findByCategory(BoardCategory.NOTICE)).thenReturn(Optional.of(noticeBoard));
+        when(noticeRepository.save(any(Notice.class))).thenAnswer(i -> i.getArguments()[0]);
+
+        //when
+        noticeService.sync(request);
+
+
+        //then
+        verify(studentJpaRepository).findById(1L);
+        verify(boardJpaRepository).findByCategory(BoardCategory.NOTICE);
+        verify(postJpaRepository,times(2)).save(any(Post.class));
+    }
+
+    @Test
+    @DisplayName("syncNotice: 1L 학생 없을시 NOT_FOUND")
+    void syncNotice_fail_studentNotFound() {
+        //given
+        NoticeItemRequest item = new NoticeItemRequest(
+                "공지1",
+                "내용입니다",
+                "2026-03-24",
+                "https://example.com",
+                1L,
+                "제목입니다",
+                "ACTIVE"
+        );
+        NoticeSyncRequest request = new NoticeSyncRequest(List.of(item));
+
+        when(studentJpaRepository.findById(1L)).thenReturn(Optional.empty());
+
+        //when
+        BusinessException ex = assertThrows(BusinessException.class,
+                () -> noticeService.sync(request));
+
+        //then
+        assertEquals(CommonErrorCode.NOT_FOUND, ex.getErrorCode());
+        verify(postJpaRepository,never()).save(any(Post.class));
+    }
+
+    @Test
+    @DisplayName("syncNotice: NOTICE 게시판이 없으면 NOT_FOUND")
+    void syncNotice_fail_noticeBoardNotFound() {
+        // given
+        NoticeItemRequest item = new NoticeItemRequest(
+                "공지1",
+                "내용입니다",
+                "2026-03-24",
+                "https://example.com",
+                1L,
+                "제목입니다",
+                "ACTIVE"
+        );
+        NoticeSyncRequest request = new NoticeSyncRequest(List.of(item));
+
+        Student student = mock(Student.class);
+        when(studentJpaRepository.findById(1L)).thenReturn(Optional.of(student));
+        when(boardJpaRepository.findByCategory(BoardCategory.NOTICE))
+                .thenReturn(Optional.empty());
+
+        // when
+        BusinessException ex = assertThrows(
+                BusinessException.class,
+                () -> noticeService.sync(request)
+        );
+
+        // then
+        assertEquals(CommonErrorCode.NOT_FOUND, ex.getErrorCode());
+        verify(postJpaRepository, never()).save(any(Post.class));
+    }
+
+
     private Post givenActiveNoticePost(Long noticeId){
         Post post = mock(Post.class);
 
@@ -450,5 +554,7 @@ public class NoticeServiceImplTest {
 
         return student;
     }
+
+
 
 }

--- a/src/test/java/knu/chcse/knucseofficialserver/application/notice/NoticeServiceImplTest.java
+++ b/src/test/java/knu/chcse/knucseofficialserver/application/notice/NoticeServiceImplTest.java
@@ -1,0 +1,454 @@
+package knu.chcse.knucseofficialserver.application.notice;
+
+import knu.chcse.knucseofficialserver.application.notice.dto.CreateNoticeRequest;
+import knu.chcse.knucseofficialserver.application.notice.dto.NoticeResponse;
+import knu.chcse.knucseofficialserver.application.notice.dto.UpdateNoticeRequest;
+import knu.chcse.knucseofficialserver.domain.entity.board.Board;
+import knu.chcse.knucseofficialserver.domain.entity.board.BoardCategory;
+import knu.chcse.knucseofficialserver.domain.entity.board.BoardJpaRepository;
+import knu.chcse.knucseofficialserver.domain.entity.post.Post;
+import knu.chcse.knucseofficialserver.domain.entity.post.PostJpaRepository;
+import knu.chcse.knucseofficialserver.domain.entity.post.PostStatus;
+import knu.chcse.knucseofficialserver.domain.entity.student.Student;
+import knu.chcse.knucseofficialserver.domain.entity.student.StudentJpaRepository;
+import knu.chcse.knucseofficialserver.domain.entity.student.StudentRole;
+import knu.chcse.knucseofficialserver.global.error.CommonErrorCode;
+import knu.chcse.knucseofficialserver.global.error.NoticeErrorCode;
+import knu.chcse.knucseofficialserver.global.exception.BusinessException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("NoticeServiceImpl 테스트")
+public class NoticeServiceImplTest {
+
+    @Mock
+    private PostJpaRepository postJpaRepository;
+    @Mock
+    private StudentJpaRepository studentJpaRepository;
+    @Mock
+    private BoardJpaRepository boardJpaRepository;
+
+    private NoticeServiceImpl noticeService;
+
+    @BeforeEach
+    void setUp(){
+        this.noticeService = new NoticeServiceImpl(postJpaRepository, studentJpaRepository, boardJpaRepository);
+    }
+
+    @Test
+    @DisplayName("createNotice: 성공")
+    void createNoticeSuccess(){
+        //given
+        Long studentNumber = 20261234L;
+        CreateNoticeRequest request = new CreateNoticeRequest("title","content");
+        Student admin = givenAdmin(studentNumber);
+        Board noticeBoard = mock(Board.class);
+        when(boardJpaRepository.findByCategory(BoardCategory.NOTICE)).thenReturn(Optional.of(noticeBoard));
+
+        //when
+        Long id = noticeService.createNotice(request,studentNumber);
+
+        //then
+        verify(postJpaRepository).save(any(Post.class));
+
+    }
+
+
+    @Test
+    @DisplayName("createNotice: 학생이 없으면 INVALID_CREDENTIALS exception")
+    void createNotice_fail_studentNotfound(){
+        //given
+        Long studentNumber = 20261234L;
+        CreateNoticeRequest request = new CreateNoticeRequest("title","content");
+        when(studentJpaRepository.findByNumber(studentNumber)).thenReturn(Optional.empty());
+
+        //when
+        BusinessException ex = assertThrows(
+                BusinessException.class,
+                () -> noticeService.createNotice(request,studentNumber)
+        );
+
+        //then
+        assertEquals(CommonErrorCode.INVALID_CREDENTIALS, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("createNotice: ADMIN이 아니면 NO_NOTICE_PERMISSION exception")
+    void createNotice_fail_notAdmin(){
+        // given
+        Long studentNumber = 20261234L;
+        CreateNoticeRequest request = new CreateNoticeRequest("title", "content");
+        Student student = givenStudent(studentNumber);
+
+        // when
+        BusinessException ex = assertThrows(BusinessException.class,
+                () -> noticeService.createNotice(request, studentNumber));
+
+        // then
+        assertEquals(NoticeErrorCode.NO_NOTICE_PERMISSION, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("createNotice: NOTICE 보드가 없으면 NOT_FOUND 예외")
+    void createNotice_fail_noticeBoardNotFound(){
+        // given
+        Long studentNumber = 20261234L;
+        CreateNoticeRequest request = new CreateNoticeRequest("title", "content");
+
+        Student admin = givenAdmin(studentNumber);
+        when(boardJpaRepository.findByCategory(BoardCategory.NOTICE)).thenReturn(Optional.empty());
+
+        // when
+        BusinessException ex = assertThrows(BusinessException.class,
+                () -> noticeService.createNotice(request, studentNumber));
+
+        // then
+        assertEquals(CommonErrorCode.NOT_FOUND, ex.getErrorCode());
+    }
+
+
+    @Test
+    @DisplayName("getNotice: 성공")
+    void getNotice_success(){
+        //given
+        Long noticeId = 1L;
+        Post post = givenNoticePost(noticeId);
+        when(post.getTitle()).thenReturn("title");
+        when(post.getContent()).thenReturn("content");
+
+        //when
+        NoticeResponse response = noticeService.getNotice(noticeId);
+
+        //then
+        assertAll(
+                () -> assertEquals("title",response.getTitle()),
+                () -> assertEquals("content",response.getContent())
+        );
+        verify(post).incrementViewCount();
+    }
+
+    @Test
+    @DisplayName("getNotice : 삭제된 글이면 NOT_FOUND")
+    void getNotice_fail_noticeBoardNotFound(){
+        //given
+        Long noticeId = 1L;
+        Post post = givenDeletedNoticePost(noticeId);
+
+        //when
+        BusinessException ex = assertThrows(
+                BusinessException.class,
+                () -> noticeService.getNotice(noticeId)
+        );
+
+        //then
+        assertEquals(CommonErrorCode.NOT_FOUND, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("getNotice : post 없는 경우 NOT_FOUND")
+    void getNotice_fail_postNotfound(){
+        //given
+        Long noticeId = 1L;
+        when(postJpaRepository.findById(noticeId)).thenReturn(Optional.empty());
+
+        //when
+        BusinessException ex = assertThrows(
+                BusinessException.class,()-> noticeService.getNotice(noticeId)
+        );
+
+        //then
+        assertEquals(CommonErrorCode.NOT_FOUND, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("getNotice : notice 글이 아니면 NOT_NOTICE")
+    void getNotice_not_notice(){
+
+        //given
+        Long noticeId = 1L;
+        Post post = mock(Post.class);
+
+        when(postJpaRepository.findById(noticeId)).thenReturn(Optional.of(post));
+        when(post.isNotice()).thenReturn(false);
+        //when
+        BusinessException ex = assertThrows(
+                BusinessException.class,()-> noticeService.getNotice(noticeId)
+        );
+
+        //then
+        assertEquals(NoticeErrorCode.NOT_NOTICE, ex.getErrorCode());
+    }
+
+
+    @Test
+    @DisplayName("updateNotice : 성공")
+    void updateNotice_success(){
+        //given
+        Long noticeId = 1L;
+        Long studentNumber = 20261234L;
+
+        UpdateNoticeRequest request = new UpdateNoticeRequest("update title", "update content");
+
+        Post post = givenNoticePost(noticeId);
+        Student admin = givenAdmin(studentNumber);
+
+        //when
+        noticeService.updateNotice(noticeId, studentNumber, request);
+
+        //then
+        verify(post).update(request.title(), request.content());
+    }
+
+    @Test
+    @DisplayName("updateNotice : post 없으면 Not_FOUND")
+    void updateNotice_fail_postNotFound(){
+        //given
+        Long noticeId = 1L;
+        Long studentNumber = 20261234L;
+        UpdateNoticeRequest request = new UpdateNoticeRequest("update title", "update content");
+
+        when(postJpaRepository.findById(noticeId)).thenReturn(Optional.empty());
+
+        //when
+        BusinessException ex = assertThrows(
+                BusinessException.class,
+                ()-> noticeService.updateNotice(noticeId, studentNumber, request)
+        );
+
+        //then
+        assertEquals(CommonErrorCode.NOT_FOUND, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("updateNotice: notice 글 아니면 NOT_NOTICE")
+    void updateNotice_fail_noticeNotice(){
+        //given
+        Long noticeId = 1L;
+        Long studentNumber = 20261234L;
+        Post post = mock(Post.class);
+        UpdateNoticeRequest request = new UpdateNoticeRequest("update title", "update content");
+
+        when(postJpaRepository.findById(noticeId)).thenReturn(Optional.of(post));
+        when(post.isNotice()).thenReturn(false);
+
+        //when
+        BusinessException ex = assertThrows(
+                BusinessException.class,
+                ()-> noticeService.updateNotice(noticeId, studentNumber, request)
+        );
+
+        //then
+        assertEquals(NoticeErrorCode.NOT_NOTICE, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("updateNotice: 삭제된 글이면 NOT_FOUND")
+    void updateNotice_fail_deleted(){
+        //given
+        Long noticeId = 1L;
+        Long studentNumber = 20261234L;
+        UpdateNoticeRequest request = new UpdateNoticeRequest("update title", "update content");
+        Post post = givenDeletedNoticePost(noticeId);
+
+        //when
+        BusinessException ex = assertThrows(
+            BusinessException.class,
+                ()-> noticeService.updateNotice(noticeId, studentNumber, request)
+        );
+
+        assertEquals(CommonErrorCode.NOT_FOUND, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("updateNotice: ADMIN 아니라면 NO_NOTICE_PERMISSION")
+    void updateNotice_fail_notAdmin(){
+        //given
+        Long noticeId = 1L;
+        Long studentNumber = 20261234L;
+        Student student = givenStudent(studentNumber);
+        UpdateNoticeRequest request = new UpdateNoticeRequest("update title", "update content");
+        Post post = givenActiveNoticePost(noticeId);
+
+        //when
+        BusinessException ex = assertThrows(
+                BusinessException.class,
+                () -> noticeService.updateNotice(noticeId, studentNumber, request)
+        );
+
+        //then
+        assertEquals(NoticeErrorCode.NO_NOTICE_PERMISSION, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("deleteNotice: 성공")
+    void deleteNotice_success(){
+        //given
+        Long noticeId = 1L;
+        Long studentNumber = 20261234L;
+        Post post = givenNoticePost(noticeId);
+        Student admin = givenAdmin(studentNumber);
+
+        //when
+        noticeService.deleteNotice(noticeId, studentNumber);
+
+        //then
+        verify(post).delete();
+    }
+
+    @Test
+    @DisplayName("deleteNotice: 이미 삭제된 글이면 NOT_FOUND")
+    void deleteNotice_fail_deleted() {
+        //given
+        Long noticeId = 1L;
+        Long studentNumber = 20261234L;
+        Post post = givenDeletedNoticePost(noticeId);
+
+        //when
+        BusinessException ex = assertThrows(
+                BusinessException.class,
+                ()-> noticeService.deleteNotice(noticeId, studentNumber)
+        );
+
+        //then
+        assertEquals(CommonErrorCode.NOT_FOUND, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("deleteNotice: post 없으면 NOT_FOUND")
+    void deleteNotice_fail_postNotFound() {
+        //given
+        Long noticeId = 1L;
+        Long studentNumber = 20261234L;
+
+        when(postJpaRepository.findById(noticeId)).thenReturn(Optional.empty());
+
+        //when
+        BusinessException ex = assertThrows(
+                BusinessException.class,
+                ()-> noticeService.deleteNotice(noticeId, studentNumber)
+        );
+
+        //then
+        assertEquals(CommonErrorCode.NOT_FOUND, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("deleteNotice: notice 게시글이 아니면 NOT_NOTICE")
+    void deleteNotice_fail_notNotice(){
+        //given
+        Long noticeId = 1L;
+        Long studentNumber = 20261234L;
+        Post post = mock(Post.class);
+
+        when(postJpaRepository.findById(noticeId)).thenReturn(Optional.of(post));
+        when(post.isNotice()).thenReturn(false);
+
+        //when
+        BusinessException ex = assertThrows(
+                BusinessException.class,
+                () -> noticeService.deleteNotice(noticeId, studentNumber)
+        );
+
+        //then
+        assertEquals(NoticeErrorCode.NOT_NOTICE, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("deleteNotice: student 없으면 INVALID_CREDENTIALS")
+    void deleteNotice_fail_studentNotFound(){
+        //given
+        Long noticeId = 1L;
+        Long studentNumber = 20261234L;
+        Post post = givenNoticePost(noticeId);
+
+        when(studentJpaRepository.findByNumber(studentNumber)).thenReturn(Optional.empty());
+
+        //when
+
+        BusinessException ex = assertThrows(
+                BusinessException.class,
+                () -> noticeService.deleteNotice(noticeId, studentNumber)
+        );
+
+        //then
+        assertEquals(CommonErrorCode.INVALID_CREDENTIALS,ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("deleteNotice: ADMIN 아니면 NO_NOTICE_PERMISSION")
+    void deleteNotice_fail_notAdmin(){
+        //given
+        Long noticeId = 1L;
+        Long studentNumber = 20261234L;
+        Student student = givenStudent(studentNumber);
+        Post post = givenNoticePost(noticeId);
+
+        //when
+        BusinessException ex = assertThrows(
+                BusinessException.class,
+                () -> noticeService.deleteNotice(noticeId, studentNumber)
+        );
+
+        //then
+        assertEquals(NoticeErrorCode.NO_NOTICE_PERMISSION, ex.getErrorCode());
+    }
+
+    private Post givenActiveNoticePost(Long noticeId){
+        Post post = mock(Post.class);
+
+        when(postJpaRepository.findById(noticeId)).thenReturn(Optional.of(post));
+        when(post.isNotice()).thenReturn(true);
+        when(post.getStatus()).thenReturn(PostStatus.ACTIVE);
+
+        return post;
+    }
+
+    private Post givenDeletedNoticePost(Long noticeId){
+        Post post = mock(Post.class);
+
+        when(postJpaRepository.findById(noticeId)).thenReturn(Optional.of(post));
+        when(post.isNotice()).thenReturn(true);
+        when(post.getStatus()).thenReturn(PostStatus.DELETED);
+
+        return post;
+    }
+
+    private Post givenNoticePost(Long noticeId){
+        Post post = mock(Post.class);
+
+        when(postJpaRepository.findById(noticeId)).thenReturn(Optional.of(post));
+        when(post.isNotice()).thenReturn(true);
+        when(post.getStatus()).thenReturn(PostStatus.ACTIVE);
+
+        return post;
+    }
+
+    private Student givenAdmin(Long studentNumber){
+        Student admin = mock(Student.class);
+
+        when(studentJpaRepository.findByNumber(studentNumber)).thenReturn(Optional.of(admin));
+        when(admin.getRole()).thenReturn(StudentRole.ADMIN);
+
+        return admin;
+    }
+
+    private Student givenStudent(Long studentNumber){
+        Student student = mock(Student.class);
+
+        when(studentJpaRepository.findByNumber(studentNumber)).thenReturn(Optional.of(student));
+        when(student.getRole()).thenReturn(StudentRole.STUDENT);
+
+        return student;
+    }
+
+}


### PR DESCRIPTION
## ✨ 구현한 기능
- resolve #15 
- 학부 홈페이지의 크롤링 결과로 들어오는 공지사항 데이터를 서버에서 받아 Notice 그리고 Post entity로 저장하는 기능 구현.
- NoticeSyncRequest 기반 공지 동기화 로직 구현
- 시스템 유저(id=1L) 조회 후 작성자로 사용하며, Notice 게시판 존재 할 시 게시글 등록
- 각 공지를 Notice entity로 저장 한 뒤 Post entity 생성 및 저장
- 예외 처리 통일
- 시스템 유저 없음 → BusinessException(CommonErrorCode.NOT_FOUND)
- NOTICE 게시판 없음 → BusinessException(CommonErrorCode.NOT_FOUND)

## test
- sync 성공
- 시스템 유저 없을 경우 ->NOT_FOUND
- NOTICE 게시판 없을 경우 ->NOT_FOUND

## 📢 논의하고 싶은 내용
-

## 🎸 기타
-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 공지사항 일괄 동기화용 API(POST /api/notices/sync) 추가 및 외부 소스에서 여러 공지사항을 한 번에 가져와 게시물로 생성하는 기능 구현
* **엔터티/저장소**
  * 공지사항을 표현하는 엔티티와 관련 저장소 추가로 공지 데이터의 영속화·조회 지원 강화
* **테스트**
  * 공지사항 서비스에 대한 단위 테스트 추가로 다양한 성공/실패 시나리오 검증 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->